### PR TITLE
Add Support For OSX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "libquantum"
-version = "0.1.2"
+version = "0.1.3"
 description = "Rust bindings for the libquantum C library."
 repository = "https://github.com/mknyszek/rust-libquantum"
 license = "GPL-3.0"
 readme = "README.md"
-authors = ["Michael Anthony Knyszek <mknyszek@gmail.com>"]
+authors = ["Michael Anthony Knyszek <mknyszek@gmail.com>", "Adam Kelly <adamkelly2201@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
 libc = "0.2"
 
 [build-dependencies]
-glob = "0.2"
 bindgen = "0.20"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Bindings for libquantum in Rust
 
-`rust-libquantum` is a library that provides safe bindings to the libquantum
+`rust-libquantum` is a library that provides safe bindings to the libquantum library (v. 1.1.1)
 C library, a quantum simulator.
 
 Like libquantum, rust-libquantum is licensed under GPL-3.0 as it links
@@ -11,7 +11,7 @@ dynamically against libquantum.
 ## Prerequisits
 
 * Rust (install [here](https://www.rustup.rs)).
-* Libquantum (can be installed from [source] or through a package manager, for example `sudo apt-get install libquantum-dev` or `brew install libquantum`)
+* Libquantum (can be installed from [source] or through a package manager, for example `sudo apt-get install libquantum-dev` or `brew install libquantum --devel`)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,23 @@
 # rust-libquantum
 
-Bindings for libquantum in Rust
+> Bindings for libquantum in Rust
 
-## Overview
-
-rust-libquantum is a library that provides safe bindings to the libquantum
+`rust-libquantum` is a library that provides safe bindings to the libquantum
 C library, a quantum simulator.
 
 Like libquantum, rust-libquantum is licensed under GPL-3.0 as it links
 dynamically against libquantum.
 
-## Requirements
+## Prerequisits
 
-### Rust
-
-This library targets the newest stable version of Rust.
-
-### libquantum Development Library
-
-Note: the below instructions should work, but have only been tested for Linux
-since I don't actually have access to development machines for any other
-systems supported by both Rust and libquantum.
-
-#### Linux
-
-Install libquantum through your favorite package management tool, or
-through [libquantum's website](http://www.libquantum.de/).
-
-For example, on Ubuntu one can install libquantum through the command
-
-```
-sudo apt-get install libquantum-dev
-```
-
-#### Mac OS X
-
-Presumably libquantum works on Mac OS X, and you can install it via homebrew
-
-```
-brew install libquantum
-```
+* Rust (install [here](https://www.rustup.rs)).
+* Libquantum (can be installed from [source] or through a package manager, for example `sudo apt-get install libquantum-dev` or `brew install libquantum`)
 
 ## Installation
 
-If you're using Cargo to manage your project, you can install through
-[crates.io](http://crates.io).
-
 ```
 [dependencies]
-libquantum = "0.1"
+libquantum = "0.2"
 ```
 
 You can also pull from GitHub to use the latest version.
@@ -62,9 +31,7 @@ Finally, you can also just clone this repository and compile with `cargo build`
 
 ## Troubleshooting
 
-If for some reason the build script cannot find `quantum.h` on your system, you
-can set the `LIBQUANTUM_INCLUDE` environment variable to be the path to
-`quantum.h`.
+If for some reason the build script cannot find `quantum.h` on your system, try installing from source
 
 ## Contributing
 

--- a/build.rs
+++ b/build.rs
@@ -1,40 +1,20 @@
 extern crate bindgen;
-extern crate glob;
-
-use glob::glob;
 
 use std::env;
-use std::path::{Path, PathBuf};
-
-fn generate_bindings(qh_path: PathBuf) {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let _ = bindgen::builder()
-        .no_unstable_rust()
-        .header(qh_path.into_os_string().into_string().unwrap())
-        .generate().unwrap()
-        .write_to_file(Path::new(&out_dir).join("quantum.rs"));
-}
+use std::path::PathBuf;
 
 fn main() {
-    println!("cargo:rustc-link-lib=quantum");
-    println!("cargo:rustc-link-lib=gomp");
+  /// Tell cargo to tell rustc to link quantum.h
+  println!("cargo:rustc-link-lib=quantum");
 
-    let mut patterns = Vec::new();
-    patterns.push("/usr/include/**/quantum.h".to_string());
-    patterns.push("/usr/local/include/**/quantum.h".to_string());
+  let bindings = bindgen::Builder::default()
+  .header("header.h")
+  .generate()
+  .expect("Unable to generate bindings");
 
-    match env::var("LIBQUANTUM_INCLUDE") {
-        Ok(path) => patterns.push(path), 
-        Err(_) => (),
-    }
-
-    for pattern in patterns.iter() {
-        for entry in glob(pattern).expect("Failed to read glob pattern") {
-            match entry {
-                Ok(path) => { generate_bindings(path); return; },
-                Err(e) => println!("{:?}", e),
-            }
-        }
-    }
-    panic!("Failed to find dependency 'quantum.h'!");
+  // Write the bindings to the $OUT_DIR/bindings.rs file.
+  let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+  bindings
+    .write_to_file(out_path.join("quantum.rs"))
+    .expect("Couldn't write bindings!");
 }

--- a/header.h
+++ b/header.h
@@ -1,0 +1,4 @@
+// This file makes the build script much simpler, as it will find 
+// quantum.h as normal
+
+#include <quantum.h>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,3 +54,7 @@ pub fn reset_gates() {
     unsafe { quantum_sys::quantum_gate_counter(-1); } 
 }
 
+/// Get the number of qubits needed to represent a number
+pub fn get_width(n: i32) -> i32 {
+  unsafe { quantum_sys::quantum_getwidth(n) }
+}

--- a/tests/qureg.rs
+++ b/tests/qureg.rs
@@ -8,6 +8,11 @@ fn width() {
 }
 
 #[test]
+fn get_width() {
+  assert_eq!(libquantum::get_width(3), 2);
+}
+
+#[test]
 fn tensor() {
     let q1 = QuReg::new(2, 0b01);
     let q2 = QuReg::new(2, 0b10);


### PR DESCRIPTION
This covers the following changes:

* I updated the README to be a bit more clear, and remove the `untested on mac`
* I changed the build script to remove glob (reduce dependencies) and remove `gomp`. `gomp` causes a fair amount of trouble on OSX and the tests still all pass without it.
* I also just added the get_width function as I needed it, that also has docs and a test.

You should also consider adding something like travis ci for build integration, as that could test the whole thing, and add a documentation build script, which is needed as  [docs.rs](https://docs.rs/crate/libquantum/0.1.2) cannot make the documentation due to its build script not having the `quantum.h` header.

Thanks for your work, and if you don't want to maintain this, I would be happy to